### PR TITLE
Add certificate password support to Connect-O365Admin

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,7 +4,8 @@
 - Added support for client secret and certificate authentication.
 - `Connect-O365Admin` now accepts `ClientId`, `ClientSecret` and `Certificate` parameters.
 - `Get-O365OAuthToken` supports app-only tokens via `client_credentials`.
-- Added `CertificatePassword` parameter for password-protected PFX files.
+- Added `CertificatePassword` parameter for password-protected PFX files. The value
+  should be provided as a `SecureString`.
 - `Connect-O365Admin` can target a specific tenant using `-Tenant` or `-DomainName`.
 
 ## 0.0.16 - 2024.12.22

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,8 @@
 - Added support for client secret and certificate authentication.
 - `Connect-O365Admin` now accepts `ClientId`, `ClientSecret` and `Certificate` parameters.
 - `Get-O365OAuthToken` supports app-only tokens via `client_credentials`.
+- Added `CertificatePassword` parameter for password-protected PFX files.
+- `Connect-O365Admin` can target a specific tenant using `-Tenant` or `-DomainName`.
 
 ## 0.0.16 - 2024.12.22
 - Update docs `Set-O365OrgForms`

--- a/Private/Get-O365OAuthToken.ps1
+++ b/Private/Get-O365OAuthToken.ps1
@@ -9,14 +9,19 @@ function Get-O365OAuthToken {
         [string] $RefreshToken,
         [switch] $Device,
         [string] $ClientSecret,
-        $Certificate
+        $Certificate,
+        [string] $CertificatePassword
     )
     $tokenEndpoint = "https://login.microsoftonline.com/$Tenant/oauth2/v2.0/token"
 
     if ($ClientSecret -or $Certificate) {
         if ($Certificate -and ($Certificate -isnot [System.Security.Cryptography.X509Certificates.X509Certificate2])) {
             if (Test-Path $Certificate) {
-                $Certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new((Resolve-Path $Certificate))
+                if ($CertificatePassword) {
+                    $Certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new((Resolve-Path $Certificate), $CertificatePassword)
+                } else {
+                    $Certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new((Resolve-Path $Certificate))
+                }
             } else {
                 throw "Certificate path '$Certificate' not found"
             }

--- a/Private/Get-O365OAuthToken.ps1
+++ b/Private/Get-O365OAuthToken.ps1
@@ -10,7 +10,7 @@ function Get-O365OAuthToken {
         [switch] $Device,
         [string] $ClientSecret,
         $Certificate,
-        [string] $CertificatePassword
+        [securestring] $CertificatePassword
     )
     $tokenEndpoint = "https://login.microsoftonline.com/$Tenant/oauth2/v2.0/token"
 

--- a/Public/Connect-O365Admin.ps1
+++ b/Public/Connect-O365Admin.ps1
@@ -6,6 +6,7 @@ function Connect-O365Admin {
         [parameter(ParameterSetName = 'App')][string] $ClientId,
         [parameter(ParameterSetName = 'App')][string] $ClientSecret,
         [parameter(ParameterSetName = 'App')] $Certificate,
+        [parameter(ParameterSetName = 'App')][string] $CertificatePassword,
         [int] $ExpiresIn = 3600,
         [int] $ExpiresTimeout = 30,
         [switch] $ForceRefresh,
@@ -26,6 +27,7 @@ function Connect-O365Admin {
             $ClientId = $Headers.ClientId
             $ClientSecret = $Headers.ClientSecret
             $Certificate = $Headers.Certificate
+            $CertificatePassword = $Headers.CertificatePassword
             $Tenant = $Headers.Tenant
             $Subscription = $Headers.Subscription
             $RefreshToken = $Headers.RefreshToken
@@ -39,6 +41,7 @@ function Connect-O365Admin {
             $ClientId = $Script:AuthorizationO365Cache.ClientId
             $ClientSecret = $Script:AuthorizationO365Cache.ClientSecret
             $Certificate = $Script:AuthorizationO365Cache.Certificate
+            $CertificatePassword = $Script:AuthorizationO365Cache.CertificatePassword
             $Tenant = $Script:AuthorizationO365Cache.Tenant
             $Subscription = $Script:AuthorizationO365Cache.Subscription
             $RefreshToken = $Script:AuthorizationO365Cache.RefreshToken
@@ -58,7 +61,7 @@ function Connect-O365Admin {
     try {
         Write-Verbose -Message "Connect-O365Admin - Acquiring token for Graph"
         if ($PSCmdlet.ParameterSetName -eq 'App') {
-            $tokenGraph = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesGraph -ClientId $ClientId -ClientSecret $ClientSecret -Certificate $Certificate
+            $tokenGraph = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesGraph -ClientId $ClientId -ClientSecret $ClientSecret -Certificate $Certificate -CertificatePassword $CertificatePassword
         } elseif ($RefreshToken -and -not $Credential -and -not $Device) {
             $tokenGraph = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesGraph -RefreshToken $RefreshToken
         } else {
@@ -79,7 +82,7 @@ function Connect-O365Admin {
     try {
         Write-Verbose -Message "Connect-O365Admin - Acquiring token for admin.microsoft.com"
         if ($PSCmdlet.ParameterSetName -eq 'App') {
-            $tokenO365 = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesO365 -ClientId $ClientId -ClientSecret $ClientSecret -Certificate $Certificate
+            $tokenO365 = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesO365 -ClientId $ClientId -ClientSecret $ClientSecret -Certificate $Certificate -CertificatePassword $CertificatePassword
         } else {
             $tokenO365 = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesO365 -RefreshToken $refresh
         }
@@ -90,7 +93,7 @@ function Connect-O365Admin {
     try {
         Write-Verbose -Message "Connect-O365Admin - Acquiring token for Azure"
         if ($PSCmdlet.ParameterSetName -eq 'App') {
-            $tokenAzure = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesAzure -ClientId $ClientId -ClientSecret $ClientSecret -Certificate $Certificate
+            $tokenAzure = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesAzure -ClientId $ClientId -ClientSecret $ClientSecret -Certificate $Certificate -CertificatePassword $CertificatePassword
         } else {
             $tokenAzure = Get-O365OAuthToken -Tenant $Tenant -Scope $ScopesAzure -RefreshToken $refresh
         }
@@ -114,6 +117,7 @@ function Connect-O365Admin {
         'ClientId'         = $ClientId
         'ClientSecret'     = $ClientSecret
         'Certificate'      = $Certificate
+        'CertificatePassword' = $CertificatePassword
         'UserName'         = $userName
         'Environment'      = 'AzureCloud'
         'Subscription'     = $Subscription

--- a/Public/Connect-O365Admin.ps1
+++ b/Public/Connect-O365Admin.ps1
@@ -6,7 +6,7 @@ function Connect-O365Admin {
         [parameter(ParameterSetName = 'App')][string] $ClientId,
         [parameter(ParameterSetName = 'App')][string] $ClientSecret,
         [parameter(ParameterSetName = 'App')] $Certificate,
-        [parameter(ParameterSetName = 'App')][string] $CertificatePassword,
+        [parameter(ParameterSetName = 'App')][securestring] $CertificatePassword,
         [int] $ExpiresIn = 3600,
         [int] $ExpiresTimeout = 30,
         [switch] $ForceRefresh,

--- a/README.MD
+++ b/README.MD
@@ -97,6 +97,25 @@ When working with multiple tenants you can target a specific tenant using the `-
 $null = Connect-O365Admin -Tenant 'contoso.onmicrosoft.com' -Verbose
 ```
 
+### Required permissions
+
+The module uses Microsoft Graph, the Azure management API and several
+undocumented endpoints under `admin.microsoft.com`. When using a client
+secret or certificate, create an app registration in Azure AD and grant it
+the permissions below:
+
+* **Microsoft Graph** – at minimum `Directory.ReadWrite.All` and any other
+  scopes needed by the commands you plan to run.
+* **Azure management** (`74658136-14ec-4630-ad9b-26e160ff0fc6`) – delegate or
+  application access to `user_impersonation`.
+* **Admin portal API** – this API is not documented, so the easiest option is
+  to run the app as a user with the Global Administrator role or grant the app
+  the same administrative roles.
+
+Interactive connections require the signed‑in account to have the same
+permissions. When working non‑interactively remember to specify `-Tenant` or
+`-DomainName` to target the correct tenant.
+
 Once the connection is established we can use the module using any GET/SET commands.
 
 ```powershell

--- a/README.MD
+++ b/README.MD
@@ -84,6 +84,17 @@ $null = Connect-O365Admin -ClientId '00000000-0000-0000-0000-000000000000' -Clie
 # using a certificate
 $cert = 'C:\path\to\app.pfx'
 $null = Connect-O365Admin -ClientId '00000000-0000-0000-0000-000000000000' -Certificate $cert
+
+# using a certificate secured with a password
+$certPath = 'C:\path\to\app.pfx'
+$certPassword = ConvertTo-SecureString 'P@ssw0rd' -AsPlainText -Force
+$null = Connect-O365Admin -ClientId '00000000-0000-0000-0000-000000000000' -Certificate $certPath -CertificatePassword $certPassword
+```
+
+When working with multiple tenants you can target a specific tenant using the `-Tenant` or `-DomainName` parameters. This is required for non-interactive connections.
+
+```powershell
+$null = Connect-O365Admin -Tenant 'contoso.onmicrosoft.com' -Verbose
 ```
 
 Once the connection is established we can use the module using any GET/SET commands.


### PR DESCRIPTION
## Summary
- support password-protected certificates in `Get-O365OAuthToken`
- pass `CertificatePassword` through `Connect-O365Admin`
- document tenant targeting and password usage
- note new parameter in changelog

## Testing
- `pwsh -NoProfile -Command ./O365Essentials.Tests.ps1` *(fails: No test files were found)*

------
https://chatgpt.com/codex/tasks/task_e_68642c0b0a14832ebf104a92f613949d